### PR TITLE
run tests against latest 4.x-dev branch instead of latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@
 language: php
 
 php:
-  - 5.6
-  - 5.5
+  - 7.2
+  - 7.3
 #  - hhvm
 
 services:
@@ -24,13 +24,13 @@ git:
 env:
   global:
     - PLUGIN_NAME=Bandwidth
-    - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
+    - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/matomo
     # this variable controls the version of Piwik your tests will run against.
     # by default it will run against the maximum support version read from plugin.json
     # (PIWIK_TEST_TARGET=maximum_supported_piwik).
     # You can also specify a specific Piwik version
     # (PIWIK_TEST_TARGET=2.16.0-b1).
-    - PIWIK_TEST_TARGET=maximum_supported_piwik
+    - PIWIK_TEST_TARGET=4.x-dev
   matrix:
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik
@@ -38,11 +38,11 @@ env:
 
 matrix:
   exclude:
-    # execute latest stable tests only w/ PHP 5.5
-    - php: 5.5
+    # execute latest stable tests only w/ PHP 7.2
+    - php: 7.2
       env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik
-    # execute UI tests only w/ PHP 5.6
-    - php: 5.5
+    # execute UI tests only w/ PHP 7.3
+    - php: 7.3
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
 
 dist: trusty
@@ -59,17 +59,17 @@ install:
   - cp -R !($PLUGIN_NAME) $PLUGIN_NAME
   - cp -R .git/ $PLUGIN_NAME/
   - cp .travis.yml $PLUGIN_NAME
-  # checkout piwik in the current directory
-  - git clone -q https://github.com/piwik/piwik.git piwik
-  - cd piwik
+  # checkout matomo in the current directory
+  - git clone -q https://github.com/matomo-org/matomo.git matomo
+  - cd matomo
   - git fetch -q --all
   - git submodule update
 
   # make sure travis-scripts repo is latest for initial travis setup
-  - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/piwik/travis-scripts.git ./tests/travis"'
+  - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/matomo-org/travis-scripts.git ./tests/travis"'
   - cd ./tests/travis ; git checkout master ; cd ../..
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"Bandwidth\" --dist-trusty --sudo-false --verbose"
+  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"Bandwidth\" --php-versions=\"7.2,7.3\" --dist-trusty --sudo-false --verbose"
   - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - ./tests/travis/checkout_test_against_branch.sh


### PR DESCRIPTION
Note: tests against `minimum_required_piwik` currently fails, as the minumim version defined was not yet released and it tries to test against branch `master` as fallback

refs matomo-org/matomo#9253